### PR TITLE
Show exact number of bookmarks in drawer and toolbar

### DIFF
--- a/app/src/main/java/com/pindroid/activity/Main.java
+++ b/app/src/main/java/com/pindroid/activity/Main.java
@@ -190,11 +190,19 @@ public class Main extends FragmentBaseActivity implements OnBookmarkSelectedList
 			int id_icon = getResources().getIdentifier(myMenuItemsIcon[res], "drawable", this.getPackageName());
 
 			NsMenuItemModel mItem = new NsMenuItemModel(id_title, id_icon);
-			if (res == 1) {
-				unreadItem = mItem;
-				mItem.counter = BookmarkManager.GetUnreadCount(app.getUsername(), this);
-			} else if (res == 2) {
-				mItem.counter = BookmarkManager.GetUntaggedCount(app.getUsername(), this);
+			switch (res) {
+				case 0:
+					mItem.counter = BookmarkManager.GetAllBookmarksCount(app.getUsername(), this);
+					break;
+				case 1:
+					unreadItem = mItem;
+					mItem.counter = BookmarkManager.GetUnreadCount(app.getUsername(), this);
+					break;
+				case 2:
+					mItem.counter = BookmarkManager.GetUntaggedCount(app.getUsername(), this);
+					break;
+				default:
+					break;
 			}
 			mAdapter.addItem(mItem);
 		}

--- a/app/src/main/java/com/pindroid/fragment/BrowseBookmarksFragment.java
+++ b/app/src/main/java/com/pindroid/fragment/BrowseBookmarksFragment.java
@@ -208,28 +208,51 @@ public class BrowseBookmarksFragment extends ListFragment
 	@Override
 	public void onResume(){
 		super.onResume();
-
-		if (query != null) {
-			if (unread) {
-				getActivity().setTitle(getString(R.string.unread_search_results_title, query));
-			} else {
-				getActivity().setTitle(getString(R.string.bookmark_search_results_title, query));
-			}
-			// TODO untagged search result
-		} else {
-			if (unread && !TextUtils.isEmpty(tagname)) {
-				getActivity().setTitle(getString(R.string.browse_my_unread_bookmarks_tagged_title, tagname));
-			} else if (unread && TextUtils.isEmpty(tagname)) {
-				getActivity().setTitle(getString(R.string.browse_my_unread_bookmarks_title));
-			} else if (untagged && TextUtils.isEmpty(tagname)) {
-				getActivity().setTitle(getString(R.string.browse_my_untagged_bookmarks_title));
-			} else if (!TextUtils.isEmpty(tagname)) {
-				getActivity().setTitle(getString(R.string.browse_my_bookmarks_tagged_title, tagname));
-			} else {
-				getActivity().setTitle(getString(R.string.browse_my_bookmarks_title));
-			}
-		}
+        updateTitle();
 	}
+
+    /**
+     * Update title for {@link Activity} which contains this fragment.<br/>
+     * Title also tells the number of bookmarks that this fragment is showing.
+     */
+    private void updateTitle() {
+        int numOfBookmarks = mAdapter.getCount();
+        String title = getTitle();
+        if (!TextUtils.isEmpty(title)) {
+            if (numOfBookmarks != 0) {
+                title = getString(R.string.browse_my_bookmarks_title_count, title, numOfBookmarks);
+            }
+            getActivity().setTitle(title);
+        }
+    }
+
+    /**
+     * Pick appropriate title for what this fragment shows
+     */
+    private String getTitle() {
+        String title = null;
+        if (query != null) {
+            if (unread) {
+                title = getString(R.string.unread_search_results_title, query);
+            } else {
+                title = getString(R.string.bookmark_search_results_title, query);
+            }
+            // TODO untagged search result
+        } else {
+            if (unread && !TextUtils.isEmpty(tagname)) {
+                title = getString(R.string.browse_my_unread_bookmarks_tagged_title, tagname);
+            } else if (unread && TextUtils.isEmpty(tagname)) {
+                title = getString(R.string.browse_my_unread_bookmarks_title);
+            } else if (untagged && TextUtils.isEmpty(tagname)) {
+                title = getString(R.string.browse_my_untagged_bookmarks_title);
+            } else if (!TextUtils.isEmpty(tagname)) {
+                title = getString(R.string.browse_my_bookmarks_tagged_title, tagname);
+            } else {
+                title = getString(R.string.browse_my_bookmarks_title);
+            }
+        }
+        return title;
+    }
 	
 	@Override
 	public void onSaveInstanceState(Bundle savedInstanceState) {
@@ -347,10 +370,12 @@ public class BrowseBookmarksFragment extends ListFragment
 	
 	public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
 	    mAdapter.swapCursor(data);
+        updateTitle();
 	}
 	
 	public void onLoaderReset(Loader<Cursor> loader) {
 	    mAdapter.swapCursor(null);
+        updateTitle();
 	}
 
     @Override

--- a/app/src/main/java/com/pindroid/platform/BookmarkManager.java
+++ b/app/src/main/java/com/pindroid/platform/BookmarkManager.java
@@ -483,7 +483,23 @@ public class BookmarkManager {
 		
 		return new CursorLoader(context, Bookmark.CONTENT_URI, projection, selection, selectionlist.toArray(new String[]{}), sortorder);
 	}
-	
+
+	public static int GetAllBookmarksCount(String username, Context context){
+		if(username == null || username.equals(""))
+			return 0;
+
+		final String[] projection = new String[] {Bookmark._ID};
+		final String selection = Bookmark.Account + "=?";
+		final String[] selectionargs = new String[]{username};
+
+		final Cursor c = context.getContentResolver().query(Bookmark.CONTENT_URI, projection, selection, selectionargs, null);
+
+		final int count = c.getCount();
+
+		c.close();
+		return count;
+	}
+
 	public static int GetUnreadCount(String username, Context context){
 		if(username == null || username.equals(""))
 			return 0;

--- a/app/src/main/java/com/pindroid/ui/NsMenuAdapter.java
+++ b/app/src/main/java/com/pindroid/ui/NsMenuAdapter.java
@@ -122,15 +122,7 @@ public class NsMenuAdapter extends ArrayAdapter<NsMenuItemModel> {
                 }
 	    	
 	    	if (holder.textCounterHolder != null){
-	    		if (item.counter > 0 && item.counter < 100){
-	    			holder.textCounterHolder.setVisibility(View.VISIBLE);
-	    			holder.textCounterHolder.setText("" + item.counter);
-	    		} else if(item.counter >= 100){
-	    			holder.textCounterHolder.setVisibility(View.VISIBLE);
-	    			holder.textCounterHolder.setText("99+");
-	    		} else {
-	    			holder.textCounterHolder.setVisibility(View.GONE);
-				}
+                holder.textCounterHolder.setText(item.counter > 0 ? String.valueOf(item.counter) : "");
 			}
 	    	
 	        if (holder.imageHolder != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="main_search_results_title">Search Results</string>
 
     <!-- BrowseBookmarks -->
+    <string name="browse_my_bookmarks_title_count">%1$s (%2$d)</string>
     <string name="browse_my_bookmarks_title">Bookmarks</string>
     <string name="browse_my_unread_bookmarks_title">Unread Bookmarks</string>
     <string name="browse_my_untagged_bookmarks_title">Untagged Bookmarks</string>


### PR DESCRIPTION
As an end-user, I would really like to see exact number of bookmarks so I implemented this.
Basically this PR does:
- Change **99+** to the exact number of bookmarks when it's greater than 100
- Show number of bookmarks on toolbar

![device-2016-09-19-012824](https://cloud.githubusercontent.com/assets/991367/18617349/8349a8d0-7e08-11e6-9f6f-f9b33ff1aa1d.png)
![device-2016-09-19-012850](https://cloud.githubusercontent.com/assets/991367/18617350/85bb76b6-7e08-11e6-978b-24d0f8a6617d.png)
