### PR TITLE
Fix Travis CI; update config compile sdk and build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   global:
     - ADB_INSTALL_TIMEOUT=10 # default is 2 minutes and sometimes is not enough
     - ANDROID_ABI=armeabi-v7a # x86 is not supported yet :(
-    - BUILD_TOOLS_VERSION=24.0.3
-    - COMPILE_SDK_VERSION=24
+    - BUILD_TOOLS_VERSION=25.0.0
+    - COMPILE_SDK_VERSION=25
     - GRADLE_OPTS="-Xmx2048m -Xms512m"
   matrix:
     - ANDROID_TARGET_VERSION=15


### PR DESCRIPTION
Was broken since someone forgot to update Travis config after build.gradle update. Should be OK now.

P. S. didn't update target SDK in config to version 25 since there is only Intel emulator for sdk 25, whereas Travis needs ARM.